### PR TITLE
Continous Integration and GCC Support

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -1,0 +1,26 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  linux-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - run: sudo apt install -yq --no-install-recommends gfortran ninja-build liblapack-dev libblas-dev
+    - run: pip3 install meson
+    - run: meson setup build_gcc --buildtype release -Dla_backend=netlib
+    - run: ninja -C build_gcc
+
+  osx-build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - run: brew install gcc ninja meson lapack
+    - run: meson setup build_gcc --buildtype release -Dla_backend=netlib
+    - run: ninja -C build_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: python
+python:
+  - 3.7
+
+# Build matrix: Run different versions of GCC and tests in parallel
+jobs:
+  include:
+    - os: linux
+      dist: bionic
+      addons:
+        apt:
+          packages:
+            - libblas-dev
+            - liblapack-dev
+            - ninja-build
+            - gfortran-5
+            - python-pip
+      env:
+        - FC=gfortran-5
+
+    - os: linux
+      dist: bionic
+      addons:
+        apt:
+          packages:
+            - libblas-dev
+            - liblapack-dev
+            - ninja-build
+            - gfortran-6
+            - python-pip
+      env:
+        - FC=gfortran-6
+
+    - os: linux
+      dist: bionic
+      addons:
+        apt:
+          packages:
+            - libblas-dev
+            - liblapack-dev
+            - ninja-build
+            - gfortran-7
+            - python-pip
+      env:
+        - FC=gfortran-7
+
+    - os: linux
+      dist: bionic
+      addons:
+        apt:
+          packages:
+            - libblas-dev
+            - liblapack-dev
+            - ninja-build
+            - gfortran-8
+            - python-pip
+      env:
+        - FC=gfortran-8
+
+install:
+  - pip3 install meson
+
+script:
+  - meson build_gcc --buildtype release -Dla_backend=netlib
+  - ninja -C build_gcc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # *stda* program for computing excited states and response functions via simplified TD-DFT methods (sTDA, sTD-DFT, and SF-sTD-DFT)
 
+[![Build Status](https://travis-ci.com/grimme-lab/stda.svg?branch=master)](https://travis-ci.com/grimme-lab/stda)
+[![Build Status](https://github.com/grimme-lab/stda/workflows/CI/badge.svg)](https://github.com/grimme-lab/stda/actions)
+
 This project provides the `stda` program.
 
 ## Installation

--- a/apbtrafo.f
+++ b/apbtrafo.f
@@ -43,20 +43,20 @@ ccccccccccccccccccccccccccccccccccc
       ij=ij*(ij+1)/2
       allocate(bmat(ij))
 
-************** read B matrix (packed) **************************
+!************* read B matrix (packed) **************************
       open(unit=52,file='bmat',form='unformatted',status='old')
       read(52)bmat      
       close(52,status='delete')
-******************************************************************
+!*****************************************************************
 
-************** blow up 0.5*B and compute (0.5*B)*X *******************
+!************* blow up 0.5*B and compute (0.5*B)*X *******************
       allocate(upper(n,n))
       call spack2tri(n,bmat,upper) ! blow up matrix, but we only need upper triangle
       deallocate(bmat)
       allocate(xnew(n,nroot))
       call ssymm('l','u',n,nroot,1.0e0,upper,n,x,n,0.e0,xnew,n)      
       deallocate(upper)
-******************************************************************
+!*****************************************************************
 !
 !******************** scale with omega_TDA ************************
 !   compute divide by omega_TDA to yield  X_new 
@@ -70,7 +70,7 @@ ccccccccccccccccccccccccccccccccccc
 !
 !!! OLD ORTHOGONALIZATION PART - NOT USED ANYMORE 
 !
-************** compute overlap: S = (X_new)**T * (X_new) *********
+!************* compute overlap: S = (X_new)**T * (X_new) *********
 !      allocate(upper(nroot,nroot))
 !      upper=0.0
 !      ! compute overlap between xpy and xnew
@@ -344,22 +344,22 @@ c     blow up symmetric matrix to its lower (upper in Lapack) triangular form
       ij=ij*(ij+1)/2
       allocate(bmat(ij))
 
-************** read 0.5*B matrix (packed) ***********************
+!************* read 0.5*B matrix (packed) ***********************
       open(unit=52,file='bmat',form='unformatted',status='old')
       read(52)bmat      
       close(52,status='delete')
-******************************************************************
+!*****************************************************************
 
-************** blow up 0.5*B and compute (0.5*B)*X ***************
+!************* blow up 0.5*B and compute (0.5*B)*X ***************
       allocate(upper(n,n))
       call spack2tri(n,bmat,upper) ! blow up matrix, but we only need upper triangle
       deallocate(bmat)
       allocate(xnew(n,nroot))
       call ssymm('l','u',n,nroot,1.e0,upper,n,x,n,0.e0,xnew,n)      
       deallocate(upper)
-******************************************************************
+!*****************************************************************
 !
-******************** scale with omega_TDA ************************
+!******************* scale with omega_TDA ************************
 !   divide by omega_TDA to yield  X_new 
       do i=1,nroot
          ef=1.0d0/(dble(e(i))+1.0d-8)
@@ -367,7 +367,7 @@ c     blow up symmetric matrix to its lower (upper in Lapack) triangular form
             xnew(j,i)=ef*xnew(j,i)
          enddo
       enddo
-******************************************************************
+!*****************************************************************
 !
 ! testwise: orthogonalize the vectors
 !
@@ -573,9 +573,9 @@ c     blow up symmetric matrix to its lower (upper in Lapack) triangular form
       end subroutine apbtrafo_uks
 
 
-***********************************************************************
-* set up 0.5*B  (packed form) in RKS case
-***********************************************************************
+!**********************************************************************
+! set up 0.5*B  (packed form) in RKS case
+!**********************************************************************
       subroutine rtdacorr(nci,ncent,no,nv,mxcnf,iconf,dak,dax
      .                    ,ed,pia,qia,pij,qab)
       use omp_lib
@@ -634,13 +634,13 @@ c     blow up symmetric matrix to its lower (upper in Lapack) triangular form
       return
 
       end subroutine rtdacorr
-***********************************************************************
+!**********************************************************************
 
 
 
-***********************************************************************
-* set up 0.5*B  (packed form) in UKS case ! 
-***********************************************************************
+!**********************************************************************
+! set up 0.5*B  (packed form) in UKS case ! 
+!**********************************************************************
        subroutine utdacorr(nexa,nexb,ncent,noa,nva,nob,nvb,mxcnfa,
      .                    mxcnfb,iconfa,iconfb,dax,piaa,qiaa,
      .                    piab,qiab,pija,qaba,pijb,qabb)
@@ -747,7 +747,7 @@ c alpha-alpha block
       return
 
       end subroutine utdacorr
-***********************************************************************
+!**********************************************************************
 
 
 cccccccccccccccccccccccccccccccccccccc
@@ -776,20 +776,20 @@ cccccccccccccccccccccccccccccccccccccc
       write(*,'(A)',advance='yes') '  perform velo correction for X...'
       allocate(bmat(n*(n+1)/2))
 
-************** read B matrix (packed) **************************
+!************* read B matrix (packed) **************************
       open(unit=52,file='bmat',form='unformatted',status='old')
       read(52)bmat      
       close(52,status='delete')
-******************************************************************
+!*****************************************************************
 
-************** blow up 0.5*B and compute (0.5*B)*X *******************
+!************* blow up 0.5*B and compute (0.5*B)*X *******************
       allocate(upper(n,n))
       call spack2tri(n,bmat,upper) ! blow up matrix, but we only need upper triangle
       deallocate(bmat)
       allocate(xnew(n,nroot))
       call ssymm('l','u',n,nroot,1.0e0,upper,n,x,n,0.e0,xnew,n)      
       deallocate(upper)
-******************************************************************
+!*****************************************************************
 !
 !******************** scale with omega_TDA ************************
 !   compute divide by omega_TDA to yield  X_new 
@@ -1074,22 +1074,22 @@ cccccccccccccccccccccccccccccccccccccc
                                                                        
       allocate(bmat(n*(n+1)/2))                                        
                                                                        
-************** read 0.5*B matrix (packed) ***********************      
+!************* read 0.5*B matrix (packed) ***********************      
       open(unit=52,file='bmat',form='unformatted',status='old')        
       read(52)bmat                                                     
       close(52,status='delete')                                        
-******************************************************************     
+!*****************************************************************     
                                                                        
-************** blow up 0.5*B and compute (0.5*B)*X ***************     
+!************* blow up 0.5*B and compute (0.5*B)*X ***************     
       allocate(upper(n,n))                                             
       call spack2tri(n,bmat,upper) ! blow up matrix, but we only need upper triangle                                                                                                                                                                                           
       deallocate(bmat)                                                 
       allocate(xnew(n,nroot))                                          
       call ssymm('l','u',n,nroot,1.e0,upper,n,x,n,0.e0,xnew,n)         
       deallocate(upper)                                                
-******************************************************************     
+!*****************************************************************     
 !                                                                      
-******************** scale with omega_TDA ************************     
+!******************* scale with omega_TDA ************************     
 !   divide by omega_TDA to yield  X_new                                
       do i=1,nroot                                                     
          ef=1.0d0/(dble(e(i))+1.0d-8)                                  
@@ -1097,7 +1097,7 @@ cccccccccccccccccccccccccccccccccccccc
             xnew(j,i)=ef*xnew(j,i)
          enddo
       enddo
-******************************************************************
+!*****************************************************************
 
       write(*,*)' writing trafoed spectral data to tda.dat ...'
       open(unit=28,file='tda.dat',status='replace')

--- a/g2molden/main.f
+++ b/g2molden/main.f
@@ -1,3 +1,20 @@
+! This file is part of stda.
+!
+! Copyright (C) 2013-2019 Stefan Grimme
+!
+! stda is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! stda is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with stda.  If not, see <https://www.gnu.org/licenses/>.
+!
 ! converts g09 output into a molden input that is readable by stda program 
       program g2molden  
       use strings

--- a/g2molden/stringmod.f90
+++ b/g2molden/stringmod.f90
@@ -1,4 +1,21 @@
-module precision
+! This file is part of stda.
+!
+! Copyright (C) 2013-2019 Stefan Grimme
+!
+! stda is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! stda is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with stda.  If not, see <https://www.gnu.org/licenses/>.
+!
+module strings
 
 ! Real kinds
 
@@ -14,11 +31,6 @@ integer, parameter :: ki8 = selected_int_kind(18)          ! double precision in
 
 integer, parameter :: kc4 = kr4                            ! single precision complex
 integer, parameter :: kc8 = kr8                            ! double precision complex
-
-end module precision
-module strings
-
-use precision
 
 private :: value_dr,value_sr,value_di,value_si
 private :: write_dr,write_sr,write_di,write_si

--- a/meson.build
+++ b/meson.build
@@ -2,18 +2,18 @@
 #
 # Copyright (C) 2019 Sebastian Ehlert
 #
-# xtb4stda is free software: you can redistribute it and/or modify it under
+# stda is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# xtb4stda is distributed in the hope that it will be useful,
+# stda is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with xtb4stda.  If not, see <https://www.gnu.org/licenses/>.
+# along with stda.  If not, see <https://www.gnu.org/licenses/>.
 
 project('stda', 'fortran',
         version: '1.6.1',
@@ -127,3 +127,4 @@ g_spec_exe = executable('g_spec', g_spec_srcs,
                         install: true)
 
 
+install_data('qc2molden.sh', install_dir: get_option('bindir'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,18 +2,18 @@
 #
 # Copyright (C) 2019 Sebastian Ehlert
 #
-# xtb4stda is free software: you can redistribute it and/or modify it under
+# stda is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# xtb4stda is distributed in the hope that it will be useful,
+# stda is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with xtb4stda.  If not, see <https://www.gnu.org/licenses/>.
+# along with stda.  If not, see <https://www.gnu.org/licenses/>.
 
 option('la_backend', type: 'combo', value: 'mkl',
        choices: ['mkl', 'openblas', 'netlib', 'custom'],

--- a/molden.f
+++ b/molden.f
@@ -161,8 +161,8 @@
 
       
  21   format(a,2i7,3f16.8)
- 22   format(i,3x,a)
- 23   format(a,3x,i,3x,a)
+ 22   format(i0,3x,a)
+ 23   format(a,3x,i0,3x,a)
  24   format(2f16.8)
  25   format(3f16.8)
 

--- a/print_nto.f
+++ b/print_nto.f
@@ -138,7 +138,7 @@
       write(14,*)'load ',fname
       
       
-      write(15,'(a,i,a)')'<h2>NTO ',k,'</h2>'
+      write(15,'(a,i0,a)')'<h2>NTO ',k,'</h2>'
       write(15,'(a)')'<table>'
       
       open(unit=13,file=fname)
@@ -320,8 +320,8 @@
       write(15,'(a)')'</html>'
       write(*,*)'NTOs written'
  21   format(a,2i7,3f16.8)
- 22   format(i,3x,a)
- 23   format(a,3x,i,3x,a)
+ 22   format(i0,3x,a)
+ 23   format(a,3x,i0,3x,a)
  24   format(2f16.8)
  25   format(3f16.8) 
  26   format(a,i5.5,a,i5.5,a)
@@ -494,7 +494,7 @@
       write(14,*)'load ',fname
       
       
-      write(15,'(a,i,a)')'<h2>NTO ',k,'</h2>'
+      write(15,'(a,i0,a)')'<h2>NTO ',k,'</h2>'
       write(15,'(a)')'<table>'
       
       open(unit=13,file=fname)
@@ -769,8 +769,8 @@
       write(15,'(a)')'</html>'
       write(*,*)'NTOs written'
  21   format(a,2i7,3f16.8)
- 22   format(i,3x,a)
- 23   format(a,3x,i,3x,a)
+ 22   format(i0,3x,a)
+ 23   format(a,3x,i0,3x,a)
  24   format(2f16.8)
  25   format(3f16.8) 
  26   format(a,i5.5,a,i5.5,a)
@@ -1424,7 +1424,7 @@
       write(14,*)'load ',fname
       
       
-      write(15,'(a,i,a)')'<h2>NTO ',k,'</h2>'
+      write(15,'(a,i0,a)')'<h2>NTO ',k,'</h2>'
       write(15,'(a)')'<table>'
       
       open(unit=13,file=fname)
@@ -1701,8 +1701,8 @@
       write(15,'(a)')'</html>'
       write(*,*)'NTOs written'
  21   format(a,2i7,3f16.8)
- 22   format(i,3x,a)
- 23   format(a,3x,i,3x,a)
+ 22   format(i0,3x,a)
+ 23   format(a,3x,i0,3x,a)
  24   format(2f16.8)
  25   format(3f16.8) 
  26   format(a,i5.5,a,i5.5,a)

--- a/readbasmold.f
+++ b/readbasmold.f
@@ -736,8 +736,8 @@ cccccccccccccccccccccccccccc
       subroutine findstr(str,lenstr,ifile,i,n)
       use strings 
       implicit none 
-      character*(lenstr), intent( in ) :: str
       integer, intent( in ) :: lenstr,i,n,ifile
+      character(lenstr), intent( in ) :: str
       character*(lenstr) arg(10)
       integer narg,ios
       character*79 line

--- a/stringmod.f90
+++ b/stringmod.f90
@@ -15,7 +15,8 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with stda.  If not, see <https://www.gnu.org/licenses/>.
 !
-module precision
+
+module strings
 
 ! Real kinds
 
@@ -31,13 +32,6 @@ integer, parameter :: ki8 = selected_int_kind(18)          ! double precision in
 
 integer, parameter :: kc4 = kr4                            ! single precision complex
 integer, parameter :: kc8 = kr8                            ! double precision complex
-
-end module precision
-
-
-module strings
-
-use precision
 
 private :: value_dr,value_sr,value_di,value_si
 private :: write_dr,write_sr,write_di,write_si


### PR DESCRIPTION
This PR aims to enable GCC support and put `stda` under CI. The GCC build is usually not used in production, but might show flaws in the code that are not an issue with the more forgiving Intel compilers.

- [x] gfortran build (GCC8 tested for build)
- [x] continous integration
  - [x] Github actions (Ubuntu/OSX) [![Build Status](https://github.com/grimme-lab/stda/workflows/CI/badge.svg)](https://github.com/grimme-lab/stda/actions)
  - [x] Travis-CI (Ubuntu GCC 5, 6, 7, 8) [![Build Status](https://travis-ci.com/grimme-lab/stda.svg?branch=master)](https://travis-ci.com/grimme-lab/stda)
- [ ] test all functionalities of `stda`

Changes:

- `stringmod.f90`: remove multiple modules that break ninja
- `print_nto.f`/`molden.f`: standard conforming format specifier
- `apbtrafo.f`: changed F77 comment symbols