### PR TITLE
Add meson build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,40 @@ export STDAHOME=$PWD
 export PATH=$PATH:$STDAHOME
 ```
 
+### Alternatives
+
+If you are not a fan of `make`, you can use [`meson`](https://mesonbuild.com/)
+as alternative, but it requires a fairly new version like 0.49 or newer for a
+decent Fortran support.
+For the default backend [`ninja`](https://ninja-build.org/) version 1.5 or newer
+has to be provided.
+
+To perform a build run:
+
+```bash
+export FC=ifort
+meson setup intel_build
+ninja -C intel_build
+```
+
+To install the `sdta` binaries to `/usr/local` use (might require `sudo`)
+
+```bash
+ninja -C build_intel install
+```
+
+For a local installation (or if you want to pack a release), modify the
+configuration by using
+
+```bash
+meson configure build_intel --prefix=/
+DESTDIR=$HOME/.local ninja -C build_intel install
+```
+
+The build system will generate binary files in `$DESTDIR/bin` (don't forget to add that to `PATH` if it is not the case).
+
+## Usage
+
 For parallel usage set the threads for OMP and the MKL linear algebra backend by
 
 ```bash
@@ -35,8 +69,6 @@ stack overflows *will* occur. Use something along the lines of this:
 ulimit -s unlimited
 export OMP_STACKSIZE=4G
 ```
-
-## Usage
 
 See the manual on the [release page](https://github.com/grimme-lab/stda/releases/latest).
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ To perform a build run:
 
 ```bash
 export FC=ifort
-meson setup intel_build
-ninja -C intel_build
+meson setup build_intel
+ninja -C build_intel
 ```
 
-To install the `sdta` binaries to `/usr/local` use (might require `sudo`)
+To install the `stda` binaries to `/usr/local` use (might require `sudo`)
 
 ```bash
 ninja -C build_intel install

--- a/meson.build
+++ b/meson.build
@@ -114,8 +114,8 @@ g2molden_srcs = [
 ]
 
 stda_exe = executable(meson.project_name(), stda_srcs,
-                          dependencies: dependencies,
-                          install: true)
+                      dependencies: dependencies,
+                      install: true)
 
 g2molden_exe = executable('g2molden', g2molden_srcs,
                           dependencies: dependencies,
@@ -123,7 +123,7 @@ g2molden_exe = executable('g2molden', g2molden_srcs,
 
 
 g_spec_exe = executable('g_spec', g_spec_srcs,
-                          dependencies: dependencies,
-                          install: true)
+                        dependencies: dependencies,
+                        install: true)
 
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-# This file is part of xtb4stda.
+# This file is part of stda.
 #
 # Copyright (C) 2019 Sebastian Ehlert
 #
@@ -73,35 +73,35 @@ if get_option('openmp')
 endif
 
 stda_srcs = [
-  'apbtrafo.f',
-  'block.f',
-  'header.f',
-  'intpack.f90',
-  'intslvm.f',
-  'io.f',
-  'linal.f',
-  'linear_response.f',
-  'main.f',
-  'molden.f',
-  'normalize.f',
-  'onetri.f',
-  'pckao.f',
-  'print_nto.f',
-  'printvec.f',
-  'prmat.f',
-  'readbasa.f',
-  'readbasmold.f',
-  'readl.f',
-  'readxtb.f',
-  'sfstda.f',
-  'sosor.f',
-  'srpapack.f',
-  'stdacommon.f90',
-  'stda.f',
-  'stda-rw.f',
-  'stringmod.f90',
-  'sutda.f',
-  'velo.f'
+    'apbtrafo.f',
+    'block.f',
+    'header.f',
+    'intpack.f90',
+    'intslvm.f',
+    'io.f',
+    'linal.f',
+    'linear_response.f',
+    'main.f',
+    'molden.f',
+    'normalize.f',
+    'onetri.f',
+    'pckao.f',
+    'print_nto.f',
+    'printvec.f',
+    'prmat.f',
+    'readbasa.f',
+    'readbasmold.f',
+    'readl.f',
+    'readxtb.f',
+    'sfstda.f',
+    'sosor.f',
+    'srpapack.f',
+    'stdacommon.f90',
+    'stda.f',
+    'stda-rw.f',
+    'stringmod.f90',
+    'sutda.f',
+    'velo.f'
 ]
 
 g_spec_srcs = [

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 project('stda', 'fortran',
         version: '1.6.1',
         license: 'LGPL3',
-        meson_version: '>=0.51')
+        meson_version: '>=0.49')
 
 fc = meson.get_compiler('fortran')
 
@@ -41,10 +41,10 @@ if la_backend == 'mkl'
   libmkl += fc.find_library('m')
   libmkl += fc.find_library('dl')
   if fc.get_id() == 'intel'
-    libmkl += [fc.find_library('mkl_intel_lp64')]
+    libmkl += fc.find_library('mkl_intel_lp64')
     libmkl += fc.find_library('mkl_intel_thread')
   else
-    libmkl += [fc.find_library('mkl_gf_lp64')]
+    libmkl += fc.find_library('mkl_gf_lp64')
     libmkl += fc.find_library('mkl_gnu_thread')
   endif
   libmkl += fc.find_library('mkl_core')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,129 @@
+# This file is part of xtb4stda.
+#
+# Copyright (C) 2019 Sebastian Ehlert
+#
+# xtb4stda is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# xtb4stda is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with xtb4stda.  If not, see <https://www.gnu.org/licenses/>.
+
+project('stda', 'fortran',
+        version: '1.6.1',
+        license: 'LGPL3',
+        meson_version: '>=0.51')
+
+fc = meson.get_compiler('fortran')
+
+if fc.get_id() == 'gcc'
+  add_project_arguments('-ffree-line-length-none', language: 'fortran')
+  add_project_arguments('-fbacktrace', language: 'fortran')
+elif fc.get_id() == 'intel'
+  add_project_arguments('-axAVX2',    language: 'fortran')
+  add_project_arguments('-traceback', language: 'fortran')
+  if get_option('static')
+    add_project_link_arguments('-static', language: 'fortran')
+  endif
+endif
+
+dependencies = []
+
+la_backend = get_option('la_backend')
+if la_backend == 'mkl'
+  libmkl = [fc.find_library('pthread')]
+  libmkl += fc.find_library('m')
+  libmkl += fc.find_library('dl')
+  if fc.get_id() == 'intel'
+    libmkl += [fc.find_library('mkl_intel_lp64')]
+    libmkl += fc.find_library('mkl_intel_thread')
+  else
+    libmkl += [fc.find_library('mkl_gf_lp64')]
+    libmkl += fc.find_library('mkl_gnu_thread')
+  endif
+  libmkl += fc.find_library('mkl_core')
+  libmkl += fc.find_library('iomp5')
+  dependencies += libmkl
+elif la_backend == 'openblas'
+  dependencies += fc.find_library('openblas', required : true)
+  dependencies += fc.find_library('lapack', required : true)
+elif la_backend == 'custom'
+  foreach lib: get_option('custom_libraries')
+    dependencies += fc.find_library(lib)
+  endforeach
+else
+  dependencies += fc.find_library('blas', required : true)
+  dependencies += fc.find_library('lapack', required : true)
+endif
+
+if get_option('openmp')
+  if fc.get_id() == 'intel'
+    add_project_arguments('-qopenmp', language : 'fortran')
+    add_project_link_arguments('-qopenmp', language : 'fortran')
+  else
+    add_project_arguments('-fopenmp', language : 'fortran')
+    add_project_link_arguments('-fopenmp', language : 'fortran')
+  endif
+endif
+
+stda_srcs = [
+  'apbtrafo.f',
+  'block.f',
+  'header.f',
+  'intpack.f90',
+  'intslvm.f',
+  'io.f',
+  'linal.f',
+  'linear_response.f',
+  'main.f',
+  'molden.f',
+  'normalize.f',
+  'onetri.f',
+  'pckao.f',
+  'print_nto.f',
+  'printvec.f',
+  'prmat.f',
+  'readbasa.f',
+  'readbasmold.f',
+  'readl.f',
+  'readxtb.f',
+  'sfstda.f',
+  'sosor.f',
+  'srpapack.f',
+  'stdacommon.f90',
+  'stda.f',
+  'stda-rw.f',
+  'stringmod.f90',
+  'sutda.f',
+  'velo.f'
+]
+
+g_spec_srcs = [
+    'g_spec/g_spec.f'
+]
+
+g2molden_srcs = [
+    'g2molden/main.f',
+    'g2molden/stringmod.f90'
+]
+
+stda_exe = executable(meson.project_name(), stda_srcs,
+                          dependencies: dependencies,
+                          install: true)
+
+g2molden_exe = executable('g2molden', g2molden_srcs,
+                          dependencies: dependencies,
+                          install: true)
+
+
+g_spec_exe = executable('g_spec', g_spec_srcs,
+                          dependencies: dependencies,
+                          install: true)
+
+

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,26 @@
+# This file is part of stda.
+#
+# Copyright (C) 2019 Sebastian Ehlert
+#
+# xtb4stda is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# xtb4stda is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with xtb4stda.  If not, see <https://www.gnu.org/licenses/>.
+
+option('la_backend', type: 'combo', value: 'mkl',
+       choices: ['mkl', 'openblas', 'netlib', 'custom'],
+       description : 'linear algebra backend')
+option('custom_libraries', type: 'array', value: [],
+       description: 'libraries to load for custom linear algebra backend')
+option('openmp', type: 'boolean', value: true,
+       description: 'use OpenMP parallelisation')
+option('static', type: 'boolean', value: true,
+       description: 'Produce statically linked executables')


### PR DESCRIPTION
**WIP**, do not merge.

A quick copy-paste-adaptation of the meson build system for `stda` (actually coming from `xtb4stda`), which can be used as an alternative to `make`. The 3 executable (`stda`, `g_spec` and `g2molden`) are compiled in the process. I'm currently checking if the binaries compiled by meson and make are producing the same output.

*Of course, since my goal is to compile `stda` on my cluster, I already included the `-Dstatic=false` option of https://github.com/grimme-lab/xtb/pull/40 so that it already works for me. Thus this PR will probably be delayed.* ;)