### PR TITLE
64 bit integer interface for MKL backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,12 +2,12 @@
 #
 # Copyright (C) 2019 Sebastian Ehlert
 #
-# xtb4stda is free software: you can redistribute it and/or modify it under
+# stda is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# xtb4stda is distributed in the hope that it will be useful,
+# stda is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
@@ -18,16 +18,26 @@
 project('stda', 'fortran',
         version: '1.6.1',
         license: 'LGPL3',
-        meson_version: '>=0.49')
+        meson_version: '>=0.51')
+
+if get_option('interface') == '64' and get_option('la_backend') != 'mkl'
+  error('64 bit integer interface only supported for MKL backend')
+endif
 
 fc = meson.get_compiler('fortran')
 
 if fc.get_id() == 'gcc'
   add_project_arguments('-ffree-line-length-none', language: 'fortran')
   add_project_arguments('-fbacktrace', language: 'fortran')
+  if get_option('interface') == '64'
+    add_project_arguments('-fdefault-integer-8', language: 'fortran')
+  endif
 elif fc.get_id() == 'intel'
   add_project_arguments('-axAVX2',    language: 'fortran')
   add_project_arguments('-traceback', language: 'fortran')
+  if get_option('interface') == '64'
+    add_project_arguments('-i8', language: 'fortran')
+  endif
   if get_option('static')
     add_project_link_arguments('-static', language: 'fortran')
   endif
@@ -41,10 +51,18 @@ if la_backend == 'mkl'
   libmkl += fc.find_library('m')
   libmkl += fc.find_library('dl')
   if fc.get_id() == 'intel'
-    libmkl += fc.find_library('mkl_intel_lp64')
+    if get_option('interface') == '64'
+      libmkl += fc.find_library('mkl_intel_ilp64')
+    else
+      libmkl += fc.find_library('mkl_intel_lp64')
+    endif
     libmkl += fc.find_library('mkl_intel_thread')
   else
-    libmkl += fc.find_library('mkl_gf_lp64')
+    if get_option('interface') == '64'
+      libmkl += fc.find_library('mkl_gf_ilp64')
+    else
+      libmkl += fc.find_library('mkl_gf_lp64')
+    endif
     libmkl += fc.find_library('mkl_gnu_thread')
   endif
   libmkl += fc.find_library('mkl_core')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,12 +2,12 @@
 #
 # Copyright (C) 2019 Sebastian Ehlert
 #
-# xtb4stda is free software: you can redistribute it and/or modify it under
+# stda is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# xtb4stda is distributed in the hope that it will be useful,
+# stda is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
@@ -24,3 +24,5 @@ option('openmp', type: 'boolean', value: true,
        description: 'use OpenMP parallelisation')
 option('static', type: 'boolean', value: true,
        description: 'Produce statically linked executables')
+option('interface', type: 'combo', value: '32', choices: ['32', '64'],
+       description: 'integer precision range in bits.')


### PR DESCRIPTION
Same idea [as here](https://github.com/grimme-lab/xtb4stda/pull/4): if `wfn.xtb` is computed through the 64 bit version of `xtb4stda`, then a 64 bit version of `stda` is required (otherwise, there is a "no atom" error message).

Tested with intel 2018: the last digits of the computed quantities changes with respect to the 32 bit version, but it remains acceptable. 

For @mdewergi : I need to check with the `-rw` option to check if it change drastically the memory/disk usage, but I need a large system to do so.