### PR TITLE
Fixes for native compile of stda on Windows

### DIFF
--- a/main.f
+++ b/main.f
@@ -32,8 +32,11 @@
       character*8 method
       integer imethod,inpchk,mform,nvec
       logical molden,da,chkinp,xtbinp
-
+#if defined (_WIN32) || defined (_WIN64) || defined (WIN32)
+      call system('echo %DATE% %TIME%')
+#else
       call system('date')
+#endif
       write(*,'(//
      .          17x,''*********************************************'')')
       write(*,'(17x,''*                                           *'')')
@@ -512,8 +515,11 @@ ccccccccccccccccccccccccccccccccc
       call sutda(ncent,nmo,nao,xyz,cc,eps,occ,ccspin,iaoat,thre,
      .           thrp,ax,alpha,beta,ptlim,nvec)
       endif
-
+#if defined(_WIN32) || defined (_WIN64) || defined (WIN32)
+      call system('echo %DATE% %TIME%')
+#else
       call system('date')
+#endif
 
       end
 

--- a/main.f
+++ b/main.f
@@ -35,7 +35,8 @@
       integer, dimension(8) :: datetimevals
       
       call date_and_time(VALUES=datetimevals)
-      print '(I0,"-",I0,"-",I0,1X,I0,":",I0,":",I0,".",I3)', datetimevals(1:3), datetimevals(5:8)
+      print '(I0,"-",I0,"-",I0,1X,I0,":",I0,":",I0,".",I3)',
+     .      datetimevals(1:3), datetimevals(5:8)
       
       write(*,'(//
      .          17x,''*********************************************'')')
@@ -517,7 +518,8 @@ ccccccccccccccccccccccccccccccccc
       endif
       
       call date_and_time(VALUES=datetimevals)
-      print '(I0,"-",I0,"-",I0,1X,I0,":",I0,":",I0,".",I3)', datetimevals(1:3), datetimevals(5:8)
+      print '(I0,"-",I0,"-",I0,1X,I0,":",I0,":",I0,".",I3)',
+     .       datetimevals(1:3), datetimevals(5:8)
 
       end
 

--- a/main.f
+++ b/main.f
@@ -32,11 +32,11 @@
       character*8 method
       integer imethod,inpchk,mform,nvec
       logical molden,da,chkinp,xtbinp
-#if defined (_WIN32) || defined (_WIN64) || defined (WIN32)
-      call system('echo %DATE% %TIME%')
-#else
-      call system('date')
-#endif
+      integer, dimension(8) :: datetimevals
+      
+      call date_and_time(VALUES=datetimevals)
+      print '(I0,"-",I0,"-",I0,1X,I0,":",I0,":",I0,".",I3)', datetimevals(1:3), datetimevals(5:8)
+      
       write(*,'(//
      .          17x,''*********************************************'')')
       write(*,'(17x,''*                                           *'')')
@@ -515,11 +515,9 @@ ccccccccccccccccccccccccccccccccc
       call sutda(ncent,nmo,nao,xyz,cc,eps,occ,ccspin,iaoat,thre,
      .           thrp,ax,alpha,beta,ptlim,nvec)
       endif
-#if defined(_WIN32) || defined (_WIN64) || defined (WIN32)
-      call system('echo %DATE% %TIME%')
-#else
-      call system('date')
-#endif
+      
+      call date_and_time(VALUES=datetimevals)
+      print '(I0,"-",I0,"-",I0,1X,I0,":",I0,":",I0,".",I3)', datetimevals(1:3), datetimevals(5:8)
 
       end
 

--- a/meson.build
+++ b/meson.build
@@ -31,12 +31,14 @@ fc = meson.get_compiler('fortran')
 if fc.get_id() == 'gcc'
   add_project_arguments('-ffree-line-length-none', language: 'fortran')
   add_project_arguments('-fbacktrace', language: 'fortran')
+  add_project_arguments('-cpp', language: 'fortran')
   if get_option('interface') == '64'
     add_project_arguments('-fdefault-integer-8', language: 'fortran')
   endif
 elif fc.get_id() == 'intel'
   add_project_arguments('-axAVX2',    language: 'fortran')
   add_project_arguments('-traceback', language: 'fortran')
+  add_project_arguments('-fpp', language: 'fortran')
   if get_option('interface') == '64'
     add_project_arguments('-i8', language: 'fortran')
   endif
@@ -46,6 +48,7 @@ elif fc.get_id() == 'intel'
 elif fc.get_id() == 'intel-cl' # for Windows with Intel Fortran
   add_project_arguments('-QxHost',    language: 'fortran')
   add_project_arguments('-traceback', language: 'fortran')
+  add_project_arguments('-fpp', language: 'fortran')
   if get_option('interface') == '64'
     add_project_arguments('-integer-size:64', language: 'fortran')
   endif

--- a/meson.build
+++ b/meson.build
@@ -50,7 +50,7 @@ elif fc.get_id() == 'intel-cl' # for Windows with Intel Fortran
     add_project_arguments('-integer-size:64', language: 'fortran')
   endif
   if get_option('static')
-    add_project_link_arguments('-MT', language: 'fortran')
+    add_project_arguments('-MT', language: 'fortran') # linker does not need MT
   endif
 endif
 
@@ -58,7 +58,9 @@ dependencies = []
 
 la_backend = get_option('la_backend')
 if la_backend == 'mkl'
-  if host_machine.system() != 'windows'
+  if host_machine.system() == 'windows'
+    libmkl = [fc.find_library('libiomp5md')]
+  else
     libmkl = [fc.find_library('pthread')]
     libmkl += fc.find_library('m')
     libmkl += fc.find_library('dl')
@@ -79,7 +81,9 @@ if la_backend == 'mkl'
     libmkl += fc.find_library('mkl_gnu_thread')
   endif
   libmkl += fc.find_library('mkl_core')
-  libmkl += fc.find_library('iomp5')
+  if host_machine.system() != 'windows'
+    libmkl += fc.find_library('iomp5')
+  endif
   dependencies += libmkl
 elif la_backend == 'openblas'
   dependencies += fc.find_library('openblas', required : true)
@@ -99,7 +103,6 @@ if get_option('openmp')
     add_project_link_arguments('-qopenmp', language : 'fortran')
   elif fc.get_id() == 'intel-cl'
     add_project_arguments('-Qopenmp', language : 'fortran')
-    add_project_link_arguments('-Qopenmp', language : 'fortran')
   else
     add_project_arguments('-fopenmp', language : 'fortran')
     add_project_link_arguments('-fopenmp', language : 'fortran')

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,9 @@ if fc.get_id() == 'gcc'
   endif
 elif fc.get_id() == 'intel'
   add_project_arguments('-axAVX2',    language: 'fortran')
-  add_project_arguments('-traceback', language: 'fortran')
+  if get_option('buildtype') == 'debug'
+    add_project_arguments('-traceback', language: 'fortran')
+  endif
   if get_option('interface') == '64'
     add_project_arguments('-i8', language: 'fortran')
   endif
@@ -45,7 +47,9 @@ elif fc.get_id() == 'intel'
   endif
 elif fc.get_id() == 'intel-cl' # for Windows with Intel Fortran
   add_project_arguments('-QaxCORE-AVX2',    language: 'fortran')
-  add_project_arguments('-traceback', language: 'fortran')
+  if get_option('buildtype') == 'debug'
+    add_project_arguments('-traceback', language: 'fortran')
+  endif
   if get_option('interface') == '64'
     add_project_arguments('-integer-size:64', language: 'fortran')
   endif

--- a/meson.build
+++ b/meson.build
@@ -41,16 +41,27 @@ elif fc.get_id() == 'intel'
   if get_option('static')
     add_project_link_arguments('-static', language: 'fortran')
   endif
+elif fc.get_id() == 'intel-cl' # for Windows with Intel Fortran
+  add_project_arguments('-QxHost',    language: 'fortran')
+  add_project_arguments('-traceback', language: 'fortran')
+  if get_option('interface') == '64'
+    add_project_arguments('-integer-size:64', language: 'fortran')
+  endif
+  if get_option('static')
+    add_project_link_arguments('-MT', language: 'fortran')
+  endif
 endif
 
 dependencies = []
 
 la_backend = get_option('la_backend')
 if la_backend == 'mkl'
-  libmkl = [fc.find_library('pthread')]
-  libmkl += fc.find_library('m')
-  libmkl += fc.find_library('dl')
-  if fc.get_id() == 'intel'
+  if host_machine.system() != 'windows'
+    libmkl = [fc.find_library('pthread')]
+    libmkl += fc.find_library('m')
+    libmkl += fc.find_library('dl')
+  endif
+  if (fc.get_id() == 'intel') or (fc.get_id() == 'intel-cl')
     if get_option('interface') == '64'
       libmkl += fc.find_library('mkl_intel_ilp64')
     else
@@ -84,6 +95,9 @@ if get_option('openmp')
   if fc.get_id() == 'intel'
     add_project_arguments('-qopenmp', language : 'fortran')
     add_project_link_arguments('-qopenmp', language : 'fortran')
+  elif fc.get_id() == 'intel-cl'
+    add_project_arguments('-Qopenmp', language : 'fortran')
+    add_project_link_arguments('-Qopenmp', language : 'fortran')
   else
     add_project_arguments('-fopenmp', language : 'fortran')
     add_project_link_arguments('-fopenmp', language : 'fortran')

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with xtb4stda.  If not, see <https://www.gnu.org/licenses/>.
 
+# modified to include options for Windows with Intel Fortran only (Shoubhik Maiti, April 2022)
+
 project('stda', 'fortran',
         version: '1.6.1',
         license: 'LGPL3',

--- a/meson.build
+++ b/meson.build
@@ -31,14 +31,12 @@ fc = meson.get_compiler('fortran')
 if fc.get_id() == 'gcc'
   add_project_arguments('-ffree-line-length-none', language: 'fortran')
   add_project_arguments('-fbacktrace', language: 'fortran')
-  add_project_arguments('-cpp', language: 'fortran')
   if get_option('interface') == '64'
     add_project_arguments('-fdefault-integer-8', language: 'fortran')
   endif
 elif fc.get_id() == 'intel'
   add_project_arguments('-axAVX2',    language: 'fortran')
   add_project_arguments('-traceback', language: 'fortran')
-  add_project_arguments('-fpp', language: 'fortran')
   if get_option('interface') == '64'
     add_project_arguments('-i8', language: 'fortran')
   endif
@@ -46,9 +44,8 @@ elif fc.get_id() == 'intel'
     add_project_link_arguments('-static', language: 'fortran')
   endif
 elif fc.get_id() == 'intel-cl' # for Windows with Intel Fortran
-  add_project_arguments('-QxHost',    language: 'fortran')
+  add_project_arguments('-QaxCORE-AVX2',    language: 'fortran')
   add_project_arguments('-traceback', language: 'fortran')
-  add_project_arguments('-fpp', language: 'fortran')
   if get_option('interface') == '64'
     add_project_arguments('-integer-size:64', language: 'fortran')
   endif


### PR DESCRIPTION
I have made changes in two files. One is replacing the `call system('date')` with fortran intrinsic subroutine `time_and_date` in `main.f` so that it works on all systems. This means that the date and time are printed at the start and end in a slightly different format than before. (e.g. `2022-4-30 6:50:10.305`)

The other file is `meson.build`, where I have added compiler flags so that it can be built on Windows with meson and Intel fortran compiler with MKL. As far as I know, makefiles are not common in Windows, so I have left them alone.